### PR TITLE
Fix: Duplicate ID for SOM-Devices

### DIFF
--- a/include/HardwareConfig/OpenKNX-Ready/Smart-MF/Devices.h
+++ b/include/HardwareConfig/OpenKNX-Ready/Smart-MF/Devices.h
@@ -39,7 +39,7 @@
 #endif
 
 #ifdef DEVICE_SMARTMF_SOM_REG
-    #define DEVICE_ID "SOM-UP-EXT-PWR"
+    #define DEVICE_ID "SOM-UP-REG"
     #define DEVICE_NAME "Smart-MF Soundmodul REG"
 
     #define SOM_BASE


### PR DESCRIPTION
ID ist doppelt vergeben.

Ist das das so die richtige?